### PR TITLE
Add auth_token in initializer for Bot()

### DIFF
--- a/python_webex/v1/Bot.py
+++ b/python_webex/v1/Bot.py
@@ -9,14 +9,22 @@ import sys
 
 class Bot(People, Room, Webhook, Message):
 
-    def __init__(self):
+    def __init__(self, auth_token=None):
 
         # declare headers and how the token will be gotten from the system
         self.URL = "https://api.ciscospark.com/"
-        self.auth_token = os.getenv("auth_token")
+
+        # looks for if the auth_token has been set in the initializer. 
+        # If not, goes looks for the `auth_token` environment variable
+        self.auth_token = auth_token if auth_token else os.getenv("auth_token")
+
 
         if self.auth_token == None:
-            sys.exit("'auth_token' not set in the environment variables")
+            print("The auth_token needs to be specified for us to identify the bot being specified.")
+            print("This can be done through: ")
+            print("    1. specifying in the intiializer. Bot('auth_token')")
+            print("    2. specifying in your environment vairiables. How environment variables are defined depends on your OS")
+            sys.exit()
         
         self.headers = {
             "Authorization": "Bearer " + self.auth_token,
@@ -37,7 +45,8 @@ class Bot(People, Room, Webhook, Message):
 
         }
 
-        # default attachment variable will hold the function that is supposed to be the default action whenever an attachment is sent to the bot
+        # default attachment variable will hold the function that is supposed to be the 
+        # default action whenever an attachment is sent to the bot
         self.default_attachment = None
 
         # maps what will happen when a file is received with a particular type of text

--- a/python_webex/v1/Card.py
+++ b/python_webex/v1/Card.py
@@ -121,9 +121,6 @@ class Card:
         self, input_id: str, input_choices:list=[], input_is_multiselect: bool = False, input_value:str = None
     ):
         self.check_if_id_exists(input_id)
-        print("*" * 70)
-        print(input_choices)
-        print("*" * 70)
         element = {
             "id": input_id,
             "type": "Input.ChoiceSet",

--- a/python_webex/v1/Message.py
+++ b/python_webex/v1/Message.py
@@ -16,10 +16,12 @@ class Message:
         details on the rooms URL parameters can be found in https://developer.webex.com/docs/api/v1/messages/create-a-message
         'files' is a list of the files(images, audios etc) you want to send to the user, if the user wants to attach files with the message
         
-        Arguments:
-		    room_id => This is a 
-		    text => The text being sent in the message 
-            files => A list of files you want to sell. Each element in the list is a directory path to the file. e.g files=['/this/is/my/path/this_image.jpg', 'this/is/my/second/path/this_pdf.pdf']
+        ----
+        Arguments
+        @ room_id: string => This is the ID of the room you are sending the message to 
+        @ text: string => The text being sent in the message 
+        @ files: list of string =>  A list of files you want to sell. Each element in the list is a directory path to the file.
+                                    e.g files=['/this/is/my/path/this_image.jpg', 'this/is/my/second/path/this_pdf.pdf']
         """
         if room_id == None:
             sys.exit("'roomId' is a required field")


### PR DESCRIPTION
**Previously**
Users of the library have been forced to set the environment variable for `auth_token` to be able to authenticate the Bot

**Currently**
When creating the bot, users can keep `Bot(auth_token="auth-token-123"`)` with auth-token-123 being their auth token. Either this and the environment variable can be used to authenticate. 

If both are used, the `Bot(auth_token="auth-token-123"`)` will be used instead of the environment variable. 